### PR TITLE
Add rotate subcommand 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ powered by the [UniDoc](https://github.com/unidoc/unidoc) PDF library.
 - [Decrypt PDF files](#decrypt)
 - [Change user/owner password](#passwd)
 - [Optimize PDF files](#optimize)
+- [Rotate PDF pages](#rotate)
 - [Add watermark images to PDF files](#watermark)
 - [Convert PDF files to grayscale](#grayscale)
 - [Validate and print PDF file information](#info)
@@ -86,7 +87,7 @@ Examples:
 unicli split input_file.pdf output_file.pdf 1-2
 unicli split -p pass input_file.pd output_file.pdf 1-2,4
 
-PAGES parameter example: 1-3,4,6-7
+PAGES argument example: 1-3,4,6-7
 Only pages 1,2,3 (1-3), 4 and 6,7 (6-7) will be present in the output file,
 while page number 5 is skipped.
 ```
@@ -111,7 +112,7 @@ unicli explode -o pages.zip input_file.pdf
 unicli explode -o pages.zip -P 1-3 input_file.pdf
 unicli explode -o pages.zip -P 1-3 -p pass input_file.pdf
 
-Pages parameter example: 1-3,4,6-7
+Pages flag example: 1-3,4,6-7
 Pages 1,2,3 (1-3), 4 and 6,7 (6-7) will be extracted, while page
 number 5 is skipped.
 ```
@@ -208,6 +209,31 @@ unicli optimize -o output_file -i 75 input_file.pdf
 unicli optimize -o output_file -i 75 -p pass input_file.pdf
 ```
 
+#### Rotate
+
+Rotate PDF file pages by a specified angle. The angle argument is specified in
+degrees and it must be a multiple of 90.
+
+```
+unicli rotate [FLAG]... INPUT_FILE ANGLE
+
+Flags:
+-o, --output-file string   Output file
+-P, --pages string         Pages to rotate
+-p, --password string      PDF file password
+
+Examples:
+unicli rotate input_file.pdf 90
+unicli rotate -- input_file.pdf -270
+unicli rotate -o output_file.pdf input_file.pdf 90
+unicli rotate -o output_file.pdf -P 1-3 input_file.pdf 90
+unicli rotate -o output_file.pdf -P 1-3 -p pass input_file.pdf 90
+
+Pages flag example: 1-3,4,6-7
+Only pages 1,2,3 (1-3), 4 and 6,7 (6-7) will be rotated, while
+page number 5 is skipped.
+```
+
 #### Watermark
 
 Add watermark images to PDF files.
@@ -226,7 +252,7 @@ unicli watermark -o output file.png input_file.pdf watermark.png
 unicli watermark -o output file.png -P 1-3 input_file.pdf watermark.png
 unicli watermark -o output file.png -P 1-3 -p pass input_file.pdf watermark.png
 
-Pages parameter example: 1-3,4,6-7
+Pages flag example: 1-3,4,6-7
 Watermark will only be applied to pages 1,2,3 (1-3), 4 and 6,7 (6-7), while
 page number 5 is skipped.
 ```
@@ -249,7 +275,7 @@ unicli grayscale -o output_file input_file.pdf
 unicli grayscale -o output_file -P 1-3 input_file.pdf
 unicli grayscale -o output_file -P 1-3 -p pass input_file.pdf
 
-Pages parameter example: 1-3,4,6-7
+Pages flag example: 1-3,4,6-7
 Only pages 1,2,3 (1-3), 4 and 6,7 (6-7) will be converted to grayscale, while
 page number 5 is skipped.
 ```
@@ -290,7 +316,7 @@ unicli extract -r images input_file.pdf
 unicli extract -r images -o images.zip input_file.pdf
 unicli extract -r images -P 1-3 -p pass -o images.zip input_file.pdf
 
-Pages parameter example: 1-3,4,6-7
+Pages flag example: 1-3,4,6-7
 Resources will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7),
 while page number 5 is skipped.
 

--- a/cmd/grayscale.go
+++ b/cmd/grayscale.go
@@ -56,6 +56,7 @@ var grayscaleCmd = &cobra.Command{
 			printUsageErr(cmd, "Invalid page range specified\n")
 		}
 
+		// Convert file to grayscale.
 		err = pdf.Grayscale(inputPath, outputPath, password, pages)
 		if err != nil {
 			printErr("Could not convert input file to grayscale: %s\n", err)

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -1,0 +1,92 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/unidoc/unicli/pdf"
+)
+
+const rotateCmdDesc = `Rotate PDF file pages by a specified angle.
+The angle argument is specified in degrees and it must be a multiple of 90.
+
+The command can be configured to rotate only the specified pages
+using the --pages parameter.
+
+An example of the pages parameter: 1-3,4,6-7
+Only pages 1,2,3 (1-3), 4 and 6,7 (6-7) will be rotated, while
+page number 5 is skipped.
+`
+
+var rotateCmdExample = fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
+	fmt.Sprintf("%s rotate input_file.pdf 90", appName),
+	fmt.Sprintf("%s rotate -- input_file.pdf -270", appName),
+	fmt.Sprintf("%s rotate -o output_file.pdf input_file.pdf 90", appName),
+	fmt.Sprintf("%s rotate -o output_file.pdf -P 1-3 input_file.pdf 90", appName),
+	fmt.Sprintf("%s rotate -o output_file.pdf -P 1-3 -p pass input_file.pdf 90", appName),
+)
+
+// rotateCmd represents the rotate command
+var rotateCmd = &cobra.Command{
+	Use:                   "rotate [FLAG]... INPUT_FILE ANGLE",
+	Short:                 "Rotate PDF file pages",
+	Long:                  rotateCmdDesc,
+	Example:               rotateCmdExample,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Parse input parameters.
+		inputPath := args[0]
+		password, _ := cmd.Flags().GetString("password")
+
+		// Parse angle parameter.
+		angle, err := strconv.Atoi(args[1])
+		if err != nil {
+			printUsageErr(cmd, "Invalid rotation angle specified\n")
+		}
+
+		// Parse output file.
+		outputPath, _ := cmd.Flags().GetString("output-file")
+		if outputPath == "" {
+			outputPath = inputPath
+		}
+
+		// Parse page range.
+		pageRange, _ := cmd.Flags().GetString("pages")
+
+		pages, err := parsePageRange(pageRange)
+		if err != nil {
+			printUsageErr(cmd, "Invalid page range specified\n")
+		}
+
+		// Rotate file.
+		outputPath, err = pdf.Rotate(inputPath, outputPath, angle, password, pages)
+		if err != nil {
+			printErr("Could not rotate input file pages: %s\n", err)
+		}
+
+		fmt.Printf("Successfully rotated %s\n", inputPath)
+		fmt.Printf("Output file saved to %s\n", outputPath)
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return errors.New("must provide the input file and the rotation angle")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rotateCmd)
+
+	rotateCmd.Flags().StringP("pages", "P", "", "Pages to rotate")
+	rotateCmd.Flags().StringP("output-file", "o", "", "Output file")
+	rotateCmd.Flags().StringP("password", "p", "", "PDF file password")
+}

--- a/pdf/rotate.go
+++ b/pdf/rotate.go
@@ -52,8 +52,38 @@ func Rotate(inputPath, outputPath string, angle int, password string, pages []in
 	}
 
 	c := unicreator.New()
-	if err = readerToCreator(r, c, pages, angle); err != nil {
-		return "", err
+	for i := 0; i < pageCount; i++ {
+		numPage := i + 1
+
+		page, err := r.GetPage(numPage)
+		if err != nil {
+			return "", err
+		}
+
+		var rotate bool
+		for _, page := range pages {
+			if page == numPage {
+				rotate = true
+				break
+			}
+		}
+
+		if err = c.AddPage(page); err != nil {
+			return "", err
+		}
+
+		if !rotate || angle == 0 {
+			continue
+		}
+
+		if err = c.RotateDeg(int64(angle)); err != nil {
+			return "", err
+		}
+	}
+
+	// Add forms.
+	if r.AcroForm != nil {
+		c.SetForms(r.AcroForm)
 	}
 
 	// Write output file.

--- a/pdf/rotate.go
+++ b/pdf/rotate.go
@@ -1,0 +1,62 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package pdf
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	unicreator "github.com/unidoc/unidoc/pdf/creator"
+)
+
+// Rotate rotates the pages of the PDF file specified by the inputPath
+// by the angle specified by the angle parameter. The rotated PDF file is saved
+// at the location specified by the outputPath parameter.
+// A password can be passed in, if the input file is encrypted.
+// If the pages parameter is nil or an empty slice, all pages are rotated.
+func Rotate(inputPath, outputPath string, angle int, password string, pages []int) (string, error) {
+	if angle%90 != 0 {
+		return "", errors.New("rotation angle must be a multiple of 90 degrees")
+	}
+
+	// Generate output path from the input path, if no output path is specified.
+	dir, inputFile := filepath.Split(inputPath)
+
+	inputFile = strings.TrimSuffix(inputFile, filepath.Ext(inputFile))
+	if outputPath == "" {
+		outputPath = filepath.Join(dir, fmt.Sprintf("%s_rotated.pdf", inputFile))
+	}
+
+	// Read input file.
+	r, pageCount, _, _, err := readPDF(inputPath, password)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare output archive.
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return "", err
+	}
+	defer outputFile.Close()
+
+	// Rotate pages.
+	if len(pages) == 0 {
+		pages = createPageRange(pageCount)
+	}
+
+	c := unicreator.New()
+	if err = readerToCreator(r, c, pages, angle); err != nil {
+		return "", err
+	}
+
+	// Write output file.
+	safe := inputPath == outputPath
+	return outputPath, writeCreatorPDF(outputPath, c, safe)
+}

--- a/pdf/utils.go
+++ b/pdf/utils.go
@@ -188,7 +188,7 @@ func readerToWriter(r *unipdf.PdfReader, w *unipdf.PdfWriter, pages []int) error
 	return nil
 }
 
-func readerToCreator(r *unipdf.PdfReader, w *unicreator.Creator, pages []int) error {
+func readerToCreator(r *unipdf.PdfReader, w *unicreator.Creator, pages []int, rotationAngle int) error {
 	if r == nil {
 		return errors.New("source PDF cannot be null")
 	}
@@ -219,6 +219,12 @@ func readerToCreator(r *unipdf.PdfReader, w *unicreator.Creator, pages []int) er
 
 		if err = w.AddPage(page); err != nil {
 			return err
+		}
+
+		if rotationAngle != 0 {
+			if err = w.RotateDeg(int64(rotationAngle)); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pdf/utils.go
+++ b/pdf/utils.go
@@ -160,6 +160,11 @@ func readerToWriter(r *unipdf.PdfReader, w *unipdf.PdfWriter, pages []int) error
 		return err
 	}
 
+	// Add optional properties
+	if ocProps, err := r.GetOCProperties(); err == nil {
+		w.SetOCProperties(ocProps)
+	}
+
 	// Add pages.
 	if len(pages) == 0 {
 		pages = createPageRange(pageCount)


### PR DESCRIPTION
The rotate subcommand rotates PDF pages by the specified angle.
Resolves #6 