### PR TITLE
Extract refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ powered by the [UniDoc](https://github.com/unidoc/unidoc) PDF library.
 - [Add watermark images to PDF files](#watermark)
 - [Convert PDF files to grayscale](#grayscale)
 - [Validate and print PDF file information](#info)
-- [Extract text from PDF files](#extract)
-- [Extract images from PDF files](#extract)
+- [Extract text from PDF files](#extract-text)
+- [Extract images from PDF files](#extract-images)
 - [Search text in PDF files](#search)
 - [Export PDF form fields as JSON](#form-export)
 - [Fill PDF form fields from JSON file](#form-fill)
@@ -320,34 +320,49 @@ unicli info input_file.pdf
 unicli info -p pass input_file.pdf
 ```
 
-#### Extract
+#### Extract text
 
-Extract resources (text, images) from PDF files.
+Extracts PDF text. The extracted text is always printed to STDOUT.
+
+```
+unicli extract text [FLAG]... INPUT_FILE
+
+Flags:
+-P, --pages string           Pages to extract text from
+-p, --user-password string   Input file password
+
+Examples:
+unicli extract text input_file.pdf
+unicli extract text -P 1-3 input_file.pdf
+unicli extract text -P 1-3 -p pass input_file.pdf
+
+Pages flag example: 1-3,4,6-7
+Text will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7), while
+page number 5 is skipped.
+```
+
+#### Extract images
+
+Extracts PDF images. The images are extracted in a ZIP file and saved at the
+destination specified by the --output-file parameter. If no output file is
+specified, the ZIP archive is saved in the same directory as the input file.
 
 ```
 unicli extract [FLAG]... INPUT_FILE
 
 Flags:
 -o, --output-file string     Output file
--P, --pages string           Pages to extract resources from
--r, --resource string        Resource to extract
+-P, --pages string           Pages to extract images from
 -p, --user-password string   Input file password
 
 Examples:
-unicli extract -r text input_file.pdf
-unicli extract -r text -P 1-3 input_file.pdf
-unicli extract -r text -P 1-3 -p pass input_file.pdf
-unicli extract -r images input_file.pdf
-unicli extract -r images -o images.zip input_file.pdf
-unicli extract -r images -P 1-3 -p pass -o images.zip input_file.pdf
+unicli extract images input_file.pdf
+unicli extract images -o images.zip input_file.pdf
+unicli extract images -P 1-3 -p pass -o images.zip input_file.pdf
 
 Pages flag example: 1-3,4,6-7
-Resources will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7),
-while page number 5 is skipped.
-
-Supported resources:
-- text
-- images
+Images will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7), while
+page number 5 is skipped.
 ```
 
 #### Search

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -74,13 +74,16 @@ var extractCmd = &cobra.Command{
 
 			fmt.Println(text)
 		case "images":
-			outputPath, err = pdf.ExtractImages(inputPath, outputPath, password, pages)
+			outputPath, count, err := pdf.ExtractImages(inputPath, outputPath, password, pages)
 			if err != nil {
 				printErr("Could not extract images: %s\n", err)
 				return
 			}
-
-			fmt.Printf("Images successfully extracted to %s\n", outputPath)
+			if count == 0 {
+				fmt.Printf("Input file does not contain any images to extract\n")
+			} else {
+				fmt.Printf("Images successfully extracted to %s\n", outputPath)
+			}
 		default:
 			printUsageErr(cmd, "Invalid resource type\n")
 		}

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -6,102 +6,18 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/spf13/cobra"
-	"github.com/unidoc/unicli/pdf"
 )
 
-const extractCmdDesc = `Extracts PDF resources.
-
-Supported resources:
-  - text
-  - images
-
-The extracted text is always printed to STDOUT.
-
-The images are extracted in a ZIP file and saved at the destination specified
-by the --output-file parameter. If no output file is specified, the ZIP
-archive is saved in the same directory as the input file.
-
-The command can be configured to extract resources only from the specified
-pages using the --pages parameter.
-
-An example of the pages parameter: 1-3,4,6-7
-Resources will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7), while page
-number 5 is skipped.
-`
-
-var extractCmdExample = fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s\n",
-	fmt.Sprintf("%s extract -r text input_file.pdf", appName),
-	fmt.Sprintf("%s extract -r text -P 1-3 input_file.pdf", appName),
-	fmt.Sprintf("%s extract -r text -P 1-3 -p pass input_file.pdf", appName),
-	fmt.Sprintf("%s extract -r images input_file.pdf", appName),
-	fmt.Sprintf("%s extract -r images -o images.zip input_file.pdf", appName),
-	fmt.Sprintf("%s extract -r images -P 1-3 -p pass -o images.zip input_file.pdf", appName),
-)
+const extractCmdDesc = `Extract PDF resources.`
 
 // extractCmd represents the extract command
 var extractCmd = &cobra.Command{
-	Use:                   "extract [FLAG]... INPUT_FILE",
-	Short:                 "Extract PDF resources",
-	Long:                  extractCmdDesc,
-	Example:               extractCmdExample,
-	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		// Parse input parameters.
-		inputPath := args[0]
-		password, _ := cmd.Flags().GetString("password")
-		outputPath, _ := cmd.Flags().GetString("output-file")
-
-		// Parse page range.
-		pageRange, _ := cmd.Flags().GetString("pages")
-
-		pages, err := parsePageRange(pageRange)
-		if err != nil {
-			printUsageErr(cmd, "Invalid page range specified\n")
-		}
-
-		// Parse resource.
-		resource, _ := cmd.Flags().GetString("resource")
-		switch resource {
-		case "text":
-			text, err := pdf.ExtractText(inputPath, password, pages)
-			if err != nil {
-				printErr("Could not extract text: %s\n", err)
-			}
-
-			fmt.Println(text)
-		case "images":
-			outputPath, count, err := pdf.ExtractImages(inputPath, outputPath, password, pages)
-			if err != nil {
-				printErr("Could not extract images: %s\n", err)
-				return
-			}
-			if count == 0 {
-				fmt.Printf("Input file does not contain any images to extract\n")
-			} else {
-				fmt.Printf("Images successfully extracted to %s\n", outputPath)
-			}
-		default:
-			printUsageErr(cmd, "Invalid resource type\n")
-		}
-	},
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return errors.New("must provide the input file")
-		}
-
-		return nil
-	},
+	Use:   "extract [FLAG]... COMMAND",
+	Short: "Extract PDF resources",
+	Long:  extractCmdDesc,
 }
 
 func init() {
 	rootCmd.AddCommand(extractCmd)
-
-	extractCmd.Flags().StringP("password", "p", "", "Input file password")
-	extractCmd.Flags().StringP("output-file", "o", "", "Output file")
-	extractCmd.Flags().StringP("resource", "r", "", "Resource to extract")
-	extractCmd.Flags().StringP("pages", "P", "", "Pages to extract resources from")
 }

--- a/cmd/extract_images.go
+++ b/cmd/extract_images.go
@@ -1,0 +1,85 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/unidoc/unicli/pdf"
+)
+
+const extractImagesCmdDesc = `Extracts PDF images.
+
+The images are extracted in a ZIP file and saved at the destination specified
+by the --output-file parameter. If no output file is specified, the ZIP
+archive is saved in the same directory as the input file.
+
+The command can be configured to extract images only from the specified
+pages using the --pages parameter.
+
+An example of the pages parameter: 1-3,4,6-7
+Images will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7), while page
+number 5 is skipped.
+`
+
+var extractImagesCmdExample = fmt.Sprintf("%s\n%s\n%s\n",
+	fmt.Sprintf("%s extract images input_file.pdf", appName),
+	fmt.Sprintf("%s extract images -o images.zip input_file.pdf", appName),
+	fmt.Sprintf("%s extract images -P 1-3 -p pass -o images.zip input_file.pdf", appName),
+)
+
+// extractImagesCmd represents the extract images command
+var extractImagesCmd = &cobra.Command{
+	Use:                   "images [FLAG]... INPUT_FILE",
+	Short:                 "Extract PDF images",
+	Long:                  extractImagesCmdDesc,
+	Example:               extractImagesCmdExample,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Parse input parameters.
+		inputPath := args[0]
+		password, _ := cmd.Flags().GetString("password")
+		outputPath, _ := cmd.Flags().GetString("output-file")
+
+		// Parse page range.
+		pageRange, _ := cmd.Flags().GetString("pages")
+
+		pages, err := parsePageRange(pageRange)
+		if err != nil {
+			printUsageErr(cmd, "Invalid page range specified\n")
+		}
+
+		// Extract images.
+		outputPath, count, err := pdf.ExtractImages(inputPath, outputPath, password, pages)
+		if err != nil {
+			printErr("Could not extract images: %s\n", err)
+			return
+		}
+
+		if count == 0 {
+			fmt.Printf("%s does not contain any images to extract\n", inputPath)
+		} else {
+			fmt.Printf("Images successfully extracted to %s\n", outputPath)
+		}
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("must provide the input file")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	extractCmd.AddCommand(extractImagesCmd)
+
+	extractImagesCmd.Flags().StringP("password", "p", "", "Input file password")
+	extractImagesCmd.Flags().StringP("output-file", "o", "", "Output file")
+	extractImagesCmd.Flags().StringP("pages", "P", "", "Pages to extract images from")
+}

--- a/cmd/extract_text.go
+++ b/cmd/extract_text.go
@@ -1,0 +1,76 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/unidoc/unicli/pdf"
+)
+
+const extractTextCmdDesc = `Extracts PDF text.
+
+The extracted text is always printed to STDOUT.
+
+The command can be configured to extract text only from the specified pages
+using the --pages parameter.
+
+An example of the pages parameter: 1-3,4,6-7
+Text will only be extracted from pages 1,2,3 (1-3), 4 and 6,7 (6-7), while page
+number 5 is skipped.
+`
+
+var extractTextCmdExample = fmt.Sprintf("%s\n%s\n%s\n",
+	fmt.Sprintf("%s extract text input_file.pdf", appName),
+	fmt.Sprintf("%s extract text -P 1-3 input_file.pdf", appName),
+	fmt.Sprintf("%s extract text -P 1-3 -p pass input_file.pdf", appName),
+)
+
+// extractTextCmd represents the extract text command
+var extractTextCmd = &cobra.Command{
+	Use:                   "text [FLAG]... INPUT_FILE",
+	Short:                 "Extract PDF text",
+	Long:                  extractTextCmdDesc,
+	Example:               extractTextCmdExample,
+	DisableFlagsInUseLine: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Parse input parameters.
+		inputPath := args[0]
+		password, _ := cmd.Flags().GetString("password")
+
+		// Parse page range.
+		pageRange, _ := cmd.Flags().GetString("pages")
+
+		pages, err := parsePageRange(pageRange)
+		if err != nil {
+			printUsageErr(cmd, "Invalid page range specified\n")
+		}
+
+		// Extract text.
+		text, err := pdf.ExtractText(inputPath, password, pages)
+		if err != nil {
+			printErr("Could not extract text: %s\n", err)
+		}
+
+		fmt.Println(text)
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("must provide the input file")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	extractCmd.AddCommand(extractTextCmd)
+
+	extractTextCmd.Flags().StringP("password", "p", "", "Input file password")
+	extractTextCmd.Flags().StringP("pages", "P", "", "Pages to extract text from")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/unidoc/unidoc v3.0.0-alpha.1+incompatible
+	github.com/unidoc/unidoc v3.0.0-alpha.2+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/unidoc/unidoc v0.0.0-20190107220337-61c13118eea9 h1:LAs8hbb7IvutjEfMGVJnn1W8CLek4Aw1gDwvOmorVow=
 github.com/unidoc/unidoc v0.0.0-20190107220337-61c13118eea9/go.mod h1:Q2TZQ4OTZg5sXOPVggJmDRROXEKSGOqUMGZFO4GTCsA=
 github.com/unidoc/unidoc v0.0.0-20190111105045-ebe3a3e57401 h1:P4NSuanPUU4e4hi/dCdZAbuoHgDI5evXAOULRZlVqoE=
@@ -12,6 +16,8 @@ github.com/unidoc/unidoc v0.0.0-20190111182447-82906a29bbf1 h1:GUa5ZQjVxha+780Vi
 github.com/unidoc/unidoc v0.0.0-20190111182447-82906a29bbf1/go.mod h1:Q2TZQ4OTZg5sXOPVggJmDRROXEKSGOqUMGZFO4GTCsA=
 github.com/unidoc/unidoc v3.0.0-alpha.1+incompatible h1:ykLCS2tM9g4SoXNfc2c43n7ZxyUB3qvRM5LZGGrKC9k=
 github.com/unidoc/unidoc v3.0.0-alpha.1+incompatible/go.mod h1:Q2TZQ4OTZg5sXOPVggJmDRROXEKSGOqUMGZFO4GTCsA=
+github.com/unidoc/unidoc v3.0.0-alpha.2+incompatible h1:u+JWm3Vm44gogyJOwNsTRguBNhiZjznHOpLV9D41obw=
+github.com/unidoc/unidoc v3.0.0-alpha.2+incompatible/go.mod h1:wEA4BQRuWYeb+l24P2SkMVqR9abp3xjMxoHqeY2uq14=
 golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b h1:VHyIDlv3XkfCa5/a81uzaoDkHH4rr81Z62g+xlnO8uM=
 golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/pdf/extract.go
+++ b/pdf/extract.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	uniextractor "github.com/unidoc/unidoc/pdf/extractor"
 )
@@ -89,6 +90,7 @@ func ExtractImages(inputPath, outputPath, password string, pages []int) (string,
 	// Create zip file.
 	zipBuffer := bytes.NewBuffer(nil)
 	w := zip.NewWriter(zipBuffer)
+	now := time.Now()
 	var countImages int
 
 	for _, numPage := range pages {
@@ -119,7 +121,10 @@ func ExtractImages(inputPath, outputPath, password string, pages []int) (string,
 				return "", 0, err
 			}
 
-			filename, err := w.Create(fmt.Sprintf("p%d_%d.jpg", numPage, i))
+			filename, err := w.CreateHeader(&zip.FileHeader{
+				Name:     (fmt.Sprintf("p%d_%d.jpg", numPage, i)),
+				Modified: now,
+			})
 			if err != nil {
 				return "", 0, err
 			}


### PR DESCRIPTION
- Use extractor package to extract images
- Split extract subcommand into extract text and extract images subcommands.
- Report if input file does not contain any images

Resolves timestamps of the images in the exported zip, reported in #28 